### PR TITLE
[EVAL] Naive RAG implementation - 10.1%

### DIFF
--- a/rag/server.py
+++ b/rag/server.py
@@ -1,7 +1,6 @@
 import sys
 import logging
 import os
-from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 from langchain_core.documents import Document
 from langchain_core.prompts import ChatPromptTemplate
@@ -24,7 +23,7 @@ env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.env')
 load_dotenv(env_path)
 
 # Create an MCP server
-mcp = FastMCP("RAG")
+mcp = FastMCP("Actuarial-RAG")
 
 # Hybrid approach: Ollama embeddings + Gemini LLM
 if not os.environ.get("GOOGLE_API_KEY"):

--- a/src/core/prompts/system-prompt/components/rules.ts
+++ b/src/core/prompts/system-prompt/components/rules.ts
@@ -8,7 +8,7 @@ const BROWSER_WAIT_RULES = ` Then if you want to test your work, you might use b
 
 const RULES_TEMPLATE_TEXT = `RULES
 
-- **ACTUARIAL ANALYSIS REQUIREMENT**: When ANY user request contains actuarial terminology, insurance concepts, loss reserving, risk assessment, or mentions actuarial methods/standards, you MUST IMMEDIATELY use the RAG MCP tools before responding. This is MANDATORY - no exceptions. Use search_friedland_paper, search_werner_modlin_paper, or search_both_papers to cross-reference the academic literature first.
+- **ACTUARIAL ANALYSIS REQUIREMENT**: When ANY user request contains actuarial terminology, insurance concepts, loss reserving, risk assessment, or mentions actuarial methods/standards, you MUST IMMEDIATELY use the RAG MCP tools before responding. This is MANDATORY - no exceptions. Use the "Actuarial-RAG" server with tools: search_friedland_paper, search_werner_modlin_paper, or search_both_papers to cross-reference the academic literature first.
 
 - Your current working directory is: {{CWD}}
 - You cannot \`cd\` into a different directory to complete a task. You are stuck operating from '{{CWD}}', so be sure to pass in the correct 'path' parameter when using tools that require a path.

--- a/src/core/prompts/system-prompt/variants/generic/template.ts
+++ b/src/core/prompts/system-prompt/variants/generic/template.ts
@@ -58,11 +58,11 @@ When a server is connected, you can use the server's tools via the \`use_mcp_too
 
 ## Actuarial Analysis Protocol
 
-**CRITICAL**: When the user presents actuarial problems, insurance questions, or requests involving actuarial analysis, you MUST automatically cross-reference the available actuarial documents using the RAG MCP service tools:
+**CRITICAL**: When the user presents actuarial problems, insurance questions, or requests involving actuarial analysis, you MUST automatically cross-reference the available actuarial documents using the "Actuarial-RAG" MCP server tools:
 
-- **search_friedland_paper**: Use for Friedland paper specific queries
-- **search_werner_modlin_paper**: Use for Werner-Modlin paper specific queries  
-- **search_both_papers**: Use for comprehensive actuarial analysis
+- **search_friedland_paper** (from "Actuarial-RAG" server): Use for Friedland paper specific queries
+- **search_werner_modlin_paper** (from "Actuarial-RAG" server): Use for Werner-Modlin paper specific queries  
+- **search_both_papers** (from "Actuarial-RAG" server): Use for comprehensive actuarial analysis
 
 **Trigger Conditions**: Automatically use these tools when encountering:
 - Actuarial calculations or methods

--- a/src/core/prompts/system-prompt/variants/next-gen/template.ts
+++ b/src/core/prompts/system-prompt/variants/next-gen/template.ts
@@ -50,7 +50,7 @@ export const baseTemplate = `{{${SystemPromptSection.AGENT_ROLE}}}
 
 export const rules_template = `RULES
 
-- **ACTUARIAL ANALYSIS REQUIREMENT**: When ANY user request contains actuarial terminology, insurance concepts, loss reserving, risk assessment, or mentions actuarial methods/standards, you MUST IMMEDIATELY use the RAG MCP tools before responding. This is MANDATORY - no exceptions. Use search_friedland_paper, search_werner_modlin_paper, or search_both_papers to cross-reference the academic literature first.
+- **ACTUARIAL ANALYSIS REQUIREMENT**: When ANY user request contains actuarial terminology, insurance concepts, loss reserving, risk assessment, or mentions actuarial methods/standards, you MUST IMMEDIATELY use the RAG MCP tools before responding. This is MANDATORY - no exceptions. Use the "Actuarial-RAG" server with tools: search_friedland_paper, search_werner_modlin_paper, or search_both_papers to cross-reference the academic literature first.
 
 - Your current working directory is: {{CWD}}
 - You cannot \`cd\` into a different directory to complete a task. You are stuck operating from '{{CWD}}', so be sure to pass in the correct 'path' parameter when using tools that require a path.
@@ -89,11 +89,11 @@ When a server is connected, you can use the server's tools via the \`use_mcp_too
 
 ## Actuarial Analysis Protocol
 
-**CRITICAL**: When the user presents actuarial problems, insurance questions, or requests involving actuarial analysis, you MUST automatically cross-reference the available actuarial documents using the RAG MCP service tools:
+**CRITICAL**: When the user presents actuarial problems, insurance questions, or requests involving actuarial analysis, you MUST automatically cross-reference the available actuarial documents using the "Actuarial-RAG" MCP server tools:
 
-- **search_friedland_paper**: Use for Friedland paper specific queries
-- **search_werner_modlin_paper**: Use for Werner-Modlin paper specific queries  
-- **search_both_papers**: Use for comprehensive actuarial analysis
+- **search_friedland_paper** (from "Actuarial-RAG" server): Use for Friedland paper specific queries
+- **search_werner_modlin_paper** (from "Actuarial-RAG" server): Use for Werner-Modlin paper specific queries  
+- **search_both_papers** (from "Actuarial-RAG" server): Use for comprehensive actuarial analysis
 
 **Trigger Conditions**: Automatically use these tools when encountering:
 - Actuarial calculations or methods


### PR DESCRIPTION
Ran test harness with naive RAG - results improve **marginally**.  
A lot of test cases just seem slightly off numerically, could mean force-use chainladder-python could help substantially. 


FINAL RESULTS
==================================================
EX5-F19-Q01: 0.00/1.75 (0/4 parts)
EX5-F19-Q02: 0.50/1.00 (2/3 parts)
EX5-F19-Q03a: 0.00/2.25 FAILED
EX5-F19-Q05ab: 1.00/1.00 (2/2 parts)
EX5-F19-Q07: 0.00/4.50 FAILED
EX5-F19-Q13: 0.00/1.75 FAILED
EX5-F19-Q18a: 0.00/1.75 FAILED
EX5-F19-Q19: 0.00/3.00 FAILED
EX5-F19-Q20a: 0.00/0.00 FAILED
EX5-F19-Q21: 0.00/2.25 FAILED
EX5-F19-Q24a: 0.00/1.50 FAILED
EX5-F19-Q25a: 0.00/1.25 (1/2 parts)
EX5-S19-Q01: 0.00/1.50 (0/4 parts)
EX5-S19-Q02a: 0.00/1.75 FAILED
EX5-S19-Q04ab: 1.00/1.75 (1/2 parts)
EX5-S19-Q05a: 0.00/3.75 FAILED
EX5-S19-Q06abd: 0.00/2.00 (0/3 parts)
EX5-SP19-Q07ab: 0.00/3.95 (0/4 parts)
EX5-SP19-Q13c: 0.00/0.75 (0/2 parts)
EX5-SP19-Q15a: 2.00/2.00 PASSED
EX5-SP19-Q16a: 0.75/0.75 PASSED
EX5-SP19-Q17ab: 0.00/2.25 (0/2 parts)
EX5-SP19-Q18a: 0.00/1.50 FAILED
EX5-SP19-Q19i_ii: 0.00/1.25 (0/2 parts)
EX5-SP19-Q20a: 0.00/1.50 FAILED
EX5-SP19-Q22: 0.00/2.50 FAILED
EX5-SP19-Q23: 0.00/1.50 FAILED
EX5-SP19-Q24a: 0.00/1.25 FAILED
==================================================
TOTAL: 5.25/51.95 (10.1%)
==================================================
Results saved to ide_results/summary_cline.json