### PR TITLE
[REVIEW] quantize embeddings

### DIFF
--- a/rag/export_index.py
+++ b/rag/export_index.py
@@ -319,13 +319,15 @@ def quantize_index(input_path: str, output_path: str):
         "scale": scale,
     }
 
+    # Capture original size before potentially overwriting
+    input_size_mb = os.path.getsize(input_path) / (1024 * 1024)
+
     # Write quantized index
     print(f"\nWriting quantized index to {output_path}...")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(index, f, ensure_ascii=False)
 
     file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
-    input_size_mb = os.path.getsize(input_path) / (1024 * 1024)
     print(f"Original size: {input_size_mb:.2f} MB")
     print(f"Quantized size: {file_size_mb:.2f} MB")
     print(f"Reduction: {(1 - file_size_mb / input_size_mb) * 100:.1f}%")

--- a/rag/export_index.py
+++ b/rag/export_index.py
@@ -16,8 +16,11 @@ Usage:
 """
 
 import argparse
+import base64
 import json
+import math
 import os
+import struct
 import sys
 import warnings
 import sqlite3
@@ -121,7 +124,6 @@ def get_child_chunks_from_db(db_file: str, table_name: str) -> list[dict[str, An
         # Parse embedding from blob
         # sqlite_vec stores embeddings as float32 arrays
         if embedding_blob:
-            import struct
             # Determine number of floats (4 bytes each)
             num_floats = len(embedding_blob) // 4
             embedding = list(struct.unpack(f'{num_floats}f', embedding_blob))
@@ -260,6 +262,79 @@ def export_index(output_path: str, rebuild: bool = False):
     print("=" * 60)
 
 
+def quantize_index(input_path: str, output_path: str):
+    """
+    Quantize an existing v2 index to v3 with scalar quantization (float32 → uint8).
+
+    Uses global min/max across all embedding values to map to [0, 255].
+    Embeddings are stored as base64-encoded uint8 arrays.
+    """
+    print("=" * 60)
+    print("Aria RAG Index Quantization (float32 → uint8)")
+    print("=" * 60)
+
+    print(f"\nReading index from {input_path}...")
+    with open(input_path, "r", encoding="utf-8") as f:
+        index = json.load(f)
+
+    if index.get("version") == 3:
+        print("Index is already quantized (version 3). Nothing to do.")
+        return
+
+    if index.get("version") != 2:
+        print(f"Error: Expected version 2 index, got version {index.get('version')}")
+        return
+
+    child_chunks = index["child_chunks"]
+    print(f"Found {len(child_chunks)} child chunks to quantize")
+
+    # Compute global min/max across all embedding values
+    global_min = math.inf
+    global_max = -math.inf
+    for chunk in child_chunks:
+        emb = chunk["embedding"]
+        chunk_min = min(emb)
+        chunk_max = max(emb)
+        if chunk_min < global_min:
+            global_min = chunk_min
+        if chunk_max > global_max:
+            global_max = chunk_max
+
+    scale = (global_max - global_min) / 255.0
+    print(f"Global min: {global_min:.6f}, max: {global_max:.6f}, scale: {scale:.6f}")
+
+    # Quantize each embedding to uint8 and base64-encode
+    for chunk in child_chunks:
+        emb = chunk["embedding"]
+        quantized = bytes(
+            min(255, max(0, round((v - global_min) / scale)))
+            for v in emb
+        )
+        chunk["embedding"] = base64.b64encode(quantized).decode("ascii")
+
+    # Update index metadata
+    index["version"] = 3
+    index["quantization"] = {
+        "min": global_min,
+        "scale": scale,
+    }
+
+    # Write quantized index
+    print(f"\nWriting quantized index to {output_path}...")
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(index, f, ensure_ascii=False)
+
+    file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
+    input_size_mb = os.path.getsize(input_path) / (1024 * 1024)
+    print(f"Original size: {input_size_mb:.2f} MB")
+    print(f"Quantized size: {file_size_mb:.2f} MB")
+    print(f"Reduction: {(1 - file_size_mb / input_size_mb) * 100:.1f}%")
+
+    print("\n" + "=" * 60)
+    print("Quantization complete!")
+    print("=" * 60)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Export the RAG index to a JSON file for the Aria VS Code extension"
@@ -270,25 +345,43 @@ def main():
         help="Force rebuild of the vector database before exporting"
     )
     parser.add_argument(
+        "--quantize",
+        action="store_true",
+        help="Quantize embeddings from float32 to uint8 (can run on existing index)"
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        default=None,
+        help="Input path for quantization (default: dist/actuarial-index.json)"
+    )
+    parser.add_argument(
         "--output",
         type=str,
         default=None,
         help="Output path for the JSON index file (default: dist/actuarial-index.json)"
     )
-    
+
     args = parser.parse_args()
-    
-    # Default output path
-    if args.output:
-        output_path = args.output
+
+    repo_root = get_root_path()
+    default_path = os.path.join(repo_root, "dist", "actuarial-index.json")
+
+    if args.quantize and not args.rebuild:
+        # Quantize-only mode: read existing index, quantize, write output
+        input_path = args.input or default_path
+        output_path = args.output or default_path
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        quantize_index(input_path, output_path)
     else:
-        repo_root = get_root_path()
-        output_path = os.path.join(repo_root, "dist", "actuarial-index.json")
-    
-    # Ensure output directory exists
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    
-    export_index(output_path, rebuild=args.rebuild)
+        # Export mode (optionally with rebuild)
+        output_path = args.output or default_path
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        export_index(output_path, rebuild=args.rebuild)
+
+        # If --quantize flag is also set, quantize the just-exported index
+        if args.quantize:
+            quantize_index(output_path, output_path)
 
 
 if __name__ == "__main__":

--- a/src/services/rag/RagService.ts
+++ b/src/services/rag/RagService.ts
@@ -13,8 +13,8 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { Logger } from "@/shared/services/Logger"
-import type { RagChildChunk, RagIndex, RagParentChunk, RagSearchResult, RagServiceConfig } from "./types"
-import { cosineSimilarity } from "./vectorMath"
+import type { RagChildChunk, RagIndex, RagParentChunk, RagQuantizationParams, RagSearchResult, RagServiceConfig } from "./types"
+import { cosineSimilarity, cosineSimilarityQuantized, quantizeVector } from "./vectorMath"
 
 // Gemini embedding model - must match the one used in Python export_index.py
 const GEMINI_EMBEDDING_MODEL = "gemini-embedding-001"
@@ -41,6 +41,8 @@ export class RagService {
 
 	private index: RagIndex | null = null
 	private parentChunkMap: Map<string, RagParentChunk> = new Map()
+	private quantizedEmbeddings: Uint8Array[] | null = null
+	private quantizationParams: RagQuantizationParams | null = null
 	private isLoading = false
 	private loadError: Error | null = null
 	private config: Required<RagServiceConfig>
@@ -108,8 +110,8 @@ export class RagService {
 			const loadTime = Date.now() - startTime
 
 			// Validate the index version
-			if (index.version !== 2) {
-				throw new Error(`Unsupported RAG index version: ${index.version}. Expected version 2 (parent-child hierarchy).`)
+			if (index.version !== 2 && index.version !== 3) {
+				throw new Error(`Unsupported RAG index version: ${index.version}. Expected version 2 or 3.`)
 			}
 
 			// Validate the index content
@@ -142,11 +144,38 @@ export class RagService {
 				Logger.log(`[RagService] Warning: ${orphanCount} child chunks have missing parent chunks`)
 			}
 
-			// Check embedding dimensions are consistent
-			const embeddingDim = index.child_chunks[0].embedding.length
-			const inconsistent = index.child_chunks.filter((c) => c.embedding.length !== embeddingDim)
-			if (inconsistent.length > 0) {
-				Logger.log(`[RagService] Warning: ${inconsistent.length} child chunks have inconsistent embedding dimensions`)
+			// Handle quantized (v3) vs unquantized (v2) embeddings
+			if (index.version === 3) {
+				if (!index.quantization) {
+					throw new Error("Version 3 index missing quantization parameters")
+				}
+				this.quantizationParams = index.quantization
+
+				// Decode base64 embeddings to Uint8Arrays
+				this.quantizedEmbeddings = []
+				for (const child of index.child_chunks) {
+					if (typeof child.embedding !== "string") {
+						throw new Error("Version 3 index has non-string embedding")
+					}
+					this.quantizedEmbeddings.push(new Uint8Array(Buffer.from(child.embedding, "base64")))
+				}
+
+				const embeddingDim = this.quantizedEmbeddings[0].length
+				const inconsistent = this.quantizedEmbeddings.filter((e) => e.length !== embeddingDim)
+				if (inconsistent.length > 0) {
+					Logger.log(`[RagService] Warning: ${inconsistent.length} child chunks have inconsistent embedding dimensions`)
+				}
+			} else {
+				// Check embedding dimensions are consistent
+				const firstEmb = index.child_chunks[0].embedding
+				if (typeof firstEmb !== "object") {
+					throw new Error("Version 2 index has non-array embedding")
+				}
+				const embeddingDim = (firstEmb as number[]).length
+				const inconsistent = index.child_chunks.filter((c) => (c.embedding as number[]).length !== embeddingDim)
+				if (inconsistent.length > 0) {
+					Logger.log(`[RagService] Warning: ${inconsistent.length} child chunks have inconsistent embedding dimensions`)
+				}
 			}
 
 			this.index = index
@@ -206,11 +235,22 @@ export class RagService {
 			// Compute similarity scores for all child chunks
 			const childMatches: Array<{ child: RagChildChunk; score: number }> = []
 
-			for (const child of this.index.child_chunks) {
-				const score = cosineSimilarity(queryEmbedding, child.embedding)
-
-				if (score >= searchConfig.minScore) {
-					childMatches.push({ child, score })
+			if (this.quantizedEmbeddings && this.quantizationParams) {
+				// Quantized path: quantize the query, compare with uint8 embeddings
+				const queryQuantized = quantizeVector(queryEmbedding, this.quantizationParams.min, this.quantizationParams.scale)
+				for (let i = 0; i < this.index.child_chunks.length; i++) {
+					const score = cosineSimilarityQuantized(queryQuantized, this.quantizedEmbeddings[i])
+					if (score >= searchConfig.minScore) {
+						childMatches.push({ child: this.index.child_chunks[i], score })
+					}
+				}
+			} else {
+				// Unquantized path: direct float comparison
+				for (const child of this.index.child_chunks) {
+					const score = cosineSimilarity(queryEmbedding, child.embedding as number[])
+					if (score >= searchConfig.minScore) {
+						childMatches.push({ child, score })
+					}
 				}
 			}
 

--- a/src/services/rag/types.ts
+++ b/src/services/rag/types.ts
@@ -33,11 +33,23 @@ export interface RagChildChunk {
 		page?: number
 		[key: string]: unknown
 	}
-	embedding: number[]
+	/** float32 array (v2) or base64-encoded uint8 array (v3) */
+	embedding: number[] | string
 }
 
 /**
- * The pre-built RAG index file format (version 2 with parent-child hierarchy)
+ * Quantization parameters for scalar quantization (float32 → uint8)
+ */
+export interface RagQuantizationParams {
+	/** Global minimum value across all embeddings */
+	min: number
+	/** Scale factor: (max - min) / 255 */
+	scale: number
+}
+
+/**
+ * The pre-built RAG index file format (version 2 or 3 with parent-child hierarchy)
+ * Version 3 adds scalar quantization of embeddings (base64-encoded uint8 arrays)
  */
 export interface RagIndex {
 	version: number
@@ -45,6 +57,8 @@ export interface RagIndex {
 	chunking_strategy: string
 	parent_chunks: RagParentChunk[]
 	child_chunks: RagChildChunk[]
+	/** Present in version 3 (quantized) indexes */
+	quantization?: RagQuantizationParams
 }
 
 /**

--- a/src/services/rag/vectorMath.ts
+++ b/src/services/rag/vectorMath.ts
@@ -58,6 +58,46 @@ export function normalize(vector: number[]): number[] {
 }
 
 /**
+ * Compute cosine similarity between two quantized uint8 vectors.
+ * Since quantization is a linear transform (v = q * scale + min),
+ * the ranking is preserved — we can compute directly on uint8 values.
+ */
+export function cosineSimilarityQuantized(a: Uint8Array, b: Uint8Array): number {
+	if (a.length !== b.length) {
+		throw new Error(`Vector length mismatch: ${a.length} vs ${b.length}`)
+	}
+
+	let dotProduct = 0
+	let normA = 0
+	let normB = 0
+
+	for (let i = 0; i < a.length; i++) {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	const magnitude = Math.sqrt(normA) * Math.sqrt(normB)
+
+	if (magnitude === 0) {
+		return 0
+	}
+
+	return dotProduct / magnitude
+}
+
+/**
+ * Quantize a float32 vector to uint8 using global min/scale parameters
+ */
+export function quantizeVector(v: number[], min: number, scale: number): Uint8Array {
+	const result = new Uint8Array(v.length)
+	for (let i = 0; i < v.length; i++) {
+		result[i] = Math.round(Math.min(255, Math.max(0, (v[i] - min) / scale)))
+	}
+	return result
+}
+
+/**
  * Compute Euclidean distance between two vectors
  */
 export function euclideanDistance(a: number[], b: number[]): number {


### PR DESCRIPTION
To reduce space using of the vector index, we now quantize our previously float32 embeddinds to int8.

To rebuild the index, the command is now:
  python3 rag/export_index.py --rebuild --quantize          # rebuild + quantize in one step

To quantize an existing actuarial-index.json, can do
python3 rag/export_index.py --quantize                    

This is the last commit in published version 1.3.0